### PR TITLE
remove miliseconds (wrong format)

### DIFF
--- a/Sources/Services/API/DefaultFigmaAPIProvider.swift
+++ b/Sources/Services/API/DefaultFigmaAPIProvider.swift
@@ -16,7 +16,7 @@ final class DefaultFigmaAPIProvider {
         static let serverBaseURL = URL(string: "https://api.figma.com")!
         static let accessTokenHeaderName = "X-Figma-Token"
         static let codingDateLocale = Locale(identifier: "en_US_POSIX")
-        static let codingDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"
+        static let codingDateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     }
 
     // MARK: - Instance Properties


### PR DESCRIPTION
Fixes #17 

Error:

> Failed with error: responseSerializationFailed(reason: Alamofire.AFError.ResponseSerializationFailureReason.decodingFailed(error: Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "lastModified", intValue: nil)], debugDescription: "Date string does not match format expected by formatter.", underlyingError: nil))))