### PR TITLE
Mob 33633 several files for token type

### DIFF
--- a/Demo/.figmagen.yml
+++ b/Demo/.figmagen.yml
@@ -41,33 +41,33 @@ tokens:
   file: https://www.figma.com/file/W6dy4CFSZWUVpVnSzNZIxA/FigmaGen-Tokens-Demo
   templates:
     colors:
-      destination: FigmaGenDemo/Generated/ColorTokens.swift
-      templateOptions:
-        publicAccess: true
+      - destination: FigmaGenDemo/Generated/ColorTokens.swift
+        templateOptions:
+          publicAccess: true
     baseColors:
-      destination: FigmaGenDemo/Generated/BaseColorTokens.swift
-      templateOptions:
-        publicAccess: true
+      - destination: FigmaGenDemo/Generated/BaseColorTokens.swift
+        templateOptions:
+          publicAccess: true
     fontFamilies:
-      destination: FigmaGenDemo/Generated/FontFamilyTokens.swift
-      templateOptions:
-        publicAccess: true
+      - destination: FigmaGenDemo/Generated/FontFamilyTokens.swift
+        templateOptions:
+          publicAccess: true
     typographies:
-      destination: FigmaGenDemo/Generated/TypographyTokens.swift
-      templateOptions:
-        publicAccess: true
-        styleTypeName: Typography
+      - destination: FigmaGenDemo/Generated/TypographyTokens.swift
+        templateOptions:
+          publicAccess: true
+          styleTypeName: Typography
     boxShadows:
-      destination: FigmaGenDemo/Generated/BoxShadowTokens.swift
-      templateOptions:
-        publicAccess: true
-        shadowTypeName: ShadowToken
+      - destination: FigmaGenDemo/Generated/BoxShadowTokens.swift
+        templateOptions:
+          publicAccess: true
+          shadowTypeName: ShadowToken
     spacing:
-      destination: FigmaGenDemo/Generated/SpacingTokens.swift
-      templateOptions:
-        publicAccess: true
+      - destination: FigmaGenDemo/Generated/SpacingTokens.swift
+        templateOptions:
+          publicAccess: true
     theme:
-      destination: FigmaGenDemo/Generated/Theme.swift
-      templateOptions:
-        publicAccess: true
-        shadowTypeName: ShadowToken
+      - destination: FigmaGenDemo/Generated/Theme.swift
+        templateOptions:
+          publicAccess: true
+          shadowTypeName: ShadowToken

--- a/Demo/.figmagen.yml
+++ b/Demo/.figmagen.yml
@@ -45,29 +45,29 @@ tokens:
         templateOptions:
           publicAccess: true
     baseColors:
-      - destination: FigmaGenDemo/Generated/BaseColorTokens.swift
-        templateOptions:
-          publicAccess: true
+      destination: FigmaGenDemo/Generated/BaseColorTokens.swift
+      templateOptions:
+        publicAccess: true
     fontFamilies:
-      - destination: FigmaGenDemo/Generated/FontFamilyTokens.swift
-        templateOptions:
-          publicAccess: true
+      destination: FigmaGenDemo/Generated/FontFamilyTokens.swift
+      templateOptions:
+        publicAccess: true
     typographies:
-      - destination: FigmaGenDemo/Generated/TypographyTokens.swift
-        templateOptions:
-          publicAccess: true
-          styleTypeName: Typography
+      destination: FigmaGenDemo/Generated/TypographyTokens.swift
+      templateOptions:
+        publicAccess: true
+        styleTypeName: Typography
     boxShadows:
-      - destination: FigmaGenDemo/Generated/BoxShadowTokens.swift
-        templateOptions:
-          publicAccess: true
-          shadowTypeName: ShadowToken
+      destination: FigmaGenDemo/Generated/BoxShadowTokens.swift
+      templateOptions:
+        publicAccess: true
+        shadowTypeName: ShadowToken
     spacing:
-      - destination: FigmaGenDemo/Generated/SpacingTokens.swift
-        templateOptions:
-          publicAccess: true
+      destination: FigmaGenDemo/Generated/SpacingTokens.swift
+      templateOptions:
+        publicAccess: true
     theme:
-      - destination: FigmaGenDemo/Generated/Theme.swift
-        templateOptions:
-          publicAccess: true
-          shadowTypeName: ShadowToken
+      destination: FigmaGenDemo/Generated/Theme.swift
+      templateOptions:
+        publicAccess: true
+        shadowTypeName: ShadowToken

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Cloud.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Cloud.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Geo.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Geo.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Phone.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Phone.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Share.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Share.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Snapchat.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Snapchat.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Star.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Star.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Telegram.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Telegram.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Viber.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/Viber.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/WeChat.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/WeChat.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/WhatsApp.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Icon/WhatsApp.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialBehance/InterfaceEssentialBehanceStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialBehance/InterfaceEssentialBehanceStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialBehance/InterfaceEssentialBehanceStyleOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialBehance/InterfaceEssentialBehanceStyleOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialDribbble/InterfaceEssentialDribbbleStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialDribbble/InterfaceEssentialDribbbleStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialDribbble/InterfaceEssentialDribbbleStyleOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialDribbble/InterfaceEssentialDribbbleStyleOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFacebook/InterfaceEssentialFacebookOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFacebook/InterfaceEssentialFacebookOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFacebook/InterfaceEssentialFacebookStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFacebook/InterfaceEssentialFacebookStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFigma/InterfaceEssentialFigmaStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFigma/InterfaceEssentialFigmaStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFigma/InterfaceEssentialFigmaStyleOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialFigma/InterfaceEssentialFigmaStyleOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialGoogle/InterfaceEssentialGoogleStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialGoogle/InterfaceEssentialGoogleStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialGoogle/InterfaceEssentialGoogleStyleOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialGoogle/InterfaceEssentialGoogleStyleOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialInstagram/InterfaceEssentialInstagramStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialInstagram/InterfaceEssentialInstagramStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialInstagram/InterfaceEssentialInstagramStyleOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialInstagram/InterfaceEssentialInstagramStyleOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialLinkedin/InterfaceEssentialLinkedinStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialLinkedin/InterfaceEssentialLinkedinStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialLinkedin/InterfaceEssentialLinkedinStyleOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialLinkedin/InterfaceEssentialLinkedinStyleOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialTwitter/InterfaceEssentialTwitterStyleFilled.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialTwitter/InterfaceEssentialTwitterStyleFilled.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialTwitter/InterfaceEssentialTwitterStyleOutlined.imageset/Contents.json
+++ b/Demo/FigmaGenDemo/Resources/Images.xcassets/Generated/Service/InterfaceEssentialTwitter/InterfaceEssentialTwitterStyleOutlined.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "FigmaGen"
+  },
+  "properties" : {
+    "preserves-vector-representation" : false
   }
 }

--- a/Sources/FigmaGen/Commands/TokensCommand.swift
+++ b/Sources/FigmaGen/Commands/TokensCommand.swift
@@ -223,41 +223,55 @@ extension TokensCommand {
 
     // MARK: - Instance Properties
 
+    // !!! Important note !!!
+    // For CLI usage of FigmaGen we don't support multiple templates for any token type.
     var configuration: TokensConfiguration {
         TokensConfiguration(
             file: resolveFileConfiguration(),
             accessToken: resolveAccessTokenConfiguration(),
             templates: TokensTemplateConfiguration(
-                colors: TokensTemplateConfiguration.Template(
-                    template: colorsTemplate.value,
-                    templateOptions: resolveTemplateOptions(colorsTemplateOptions.value),
-                    destination: colorsDestination.value
-                ),
-                baseColors: TokensTemplateConfiguration.Template(
-                    template: baseColorsTemplate.value,
-                    templateOptions: resolveTemplateOptions(baseColorsTemplateOptions.value),
-                    destination: baseColorsDestination.value
-                ),
-                fontFamilies: TokensTemplateConfiguration.Template(
-                    template: fontFamiliesTemplate.value,
-                    templateOptions: resolveTemplateOptions(fontFamiliesTemplateOptions.value),
-                    destination: fontFamiliesDestination.value
-                ),
-                typographies: TokensTemplateConfiguration.Template(
-                    template: typographiesTemplate.value,
-                    templateOptions: resolveTemplateOptions(typographiesTemplateOptions.value),
-                    destination: typographiesDestination.value
-                ),
-                boxShadows: TokensTemplateConfiguration.Template(
-                    template: boxShadowsTemplate.value,
-                    templateOptions: resolveTemplateOptions(boxShadowsTemplateOptions.value),
-                    destination: boxShadowsDestination.value
-                ),
-                theme: TokensTemplateConfiguration.Template(
-                    template: themeTemplate.value,
-                    templateOptions: resolveTemplateOptions(themeTemplateOptions.value),
-                    destination: themeDestination.value
-                ),
+                colors: [
+                    TokensTemplateConfiguration.Template(
+                        template: colorsTemplate.value,
+                        templateOptions: resolveTemplateOptions(colorsTemplateOptions.value),
+                        destination: colorsDestination.value
+                    )
+                ],
+                baseColors: [
+                    TokensTemplateConfiguration.Template(
+                        template: baseColorsTemplate.value,
+                        templateOptions: resolveTemplateOptions(baseColorsTemplateOptions.value),
+                        destination: baseColorsDestination.value
+                    )
+                ],
+                fontFamilies: [
+                    TokensTemplateConfiguration.Template(
+                        template: fontFamiliesTemplate.value,
+                        templateOptions: resolveTemplateOptions(fontFamiliesTemplateOptions.value),
+                        destination: fontFamiliesDestination.value
+                    )
+                ],
+                typographies: [
+                    TokensTemplateConfiguration.Template(
+                        template: typographiesTemplate.value,
+                        templateOptions: resolveTemplateOptions(typographiesTemplateOptions.value),
+                        destination: typographiesDestination.value
+                    )
+                ],
+                boxShadows: [
+                    TokensTemplateConfiguration.Template(
+                        template: boxShadowsTemplate.value,
+                        templateOptions: resolveTemplateOptions(boxShadowsTemplateOptions.value),
+                        destination: boxShadowsDestination.value
+                    )
+                ],
+                theme: [
+                    TokensTemplateConfiguration.Template(
+                        template: themeTemplate.value,
+                        templateOptions: resolveTemplateOptions(themeTemplateOptions.value),
+                        destination: themeDestination.value
+                    )
+                ],
                 spacing: [
                     TokensTemplateConfiguration.Template(
                         template: spacingTemplate.value,

--- a/Sources/FigmaGen/Commands/TokensCommand.swift
+++ b/Sources/FigmaGen/Commands/TokensCommand.swift
@@ -258,11 +258,13 @@ extension TokensCommand {
                     templateOptions: resolveTemplateOptions(themeTemplateOptions.value),
                     destination: themeDestination.value
                 ),
-                spacing: TokensTemplateConfiguration.Template(
-                    template: spacingTemplate.value,
-                    templateOptions: resolveTemplateOptions(spacingTemplateOptions.value),
-                    destination: spacingDestination.value
-                )
+                spacing: [
+                    TokensTemplateConfiguration.Template(
+                        template: spacingTemplate.value,
+                        templateOptions: resolveTemplateOptions(spacingTemplateOptions.value),
+                        destination: spacingDestination.value
+                    )
+                ]
             )
         )
     }

--- a/Sources/FigmaGen/Generators/Tokens/DefaultTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/DefaultTokensGenerator.swift
@@ -55,11 +55,13 @@ final class DefaultTokensGenerator: TokensGenerator {
     }
 
     private func generateSpacingTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let spacingRenderParameters = parameters.tokens.spacingRender {
-            try spacingTokensGenerator.generate(
-                renderParameters: spacingRenderParameters,
-                tokenValues: tokenValues
-            )
+        if let spacingRenderParameters = parameters.tokens.spacingRenderParameters {
+            for renderParameters in spacingRenderParameters {
+                try spacingTokensGenerator.generate(
+                    renderParameters: renderParameters,
+                    tokenValues: tokenValues
+                )
+            }
         }
     }
 

--- a/Sources/FigmaGen/Generators/Tokens/DefaultTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/DefaultTokensGenerator.swift
@@ -66,56 +66,68 @@ final class DefaultTokensGenerator: TokensGenerator {
     }
 
     private func generateThemeTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let themeRenderParameters = parameters.tokens.themeRender {
-            try themeTokensGenerator.generate(
-                renderParameters: themeRenderParameters,
-                tokenValues: tokenValues
-            )
+        if let themeRenderParameters = parameters.tokens.themeRenderParameters {
+            for renderParameters in themeRenderParameters {
+                try themeTokensGenerator.generate(
+                    renderParameters: renderParameters,
+                    tokenValues: tokenValues
+                )
+            }
         }
     }
 
     private func generateBoxShadowTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let boxShadowRenderParameters = parameters.tokens.boxShadowRender {
-            try boxShadowTokensGenerator.generate(
-                renderParameters: boxShadowRenderParameters,
-                tokenValues: tokenValues
-            )
+        if let boxShadowRenderParameters = parameters.tokens.boxShadowRenderParameters {
+            for renderParameters in boxShadowRenderParameters {
+                try boxShadowTokensGenerator.generate(
+                    renderParameters: renderParameters,
+                    tokenValues: tokenValues
+                )
+            }
         }
     }
 
     private func generateTypographyTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let typographyRenderParameters = parameters.tokens.typographyRender {
-            try typographyTokensGenerator.generate(
-                renderParameters: typographyRenderParameters,
-                tokenValues: tokenValues
-            )
+        if let typographyRenderParameters = parameters.tokens.typographyRenderParameters {
+            for renderParameters in typographyRenderParameters {
+                try typographyTokensGenerator.generate(
+                    renderParameters: renderParameters,
+                    tokenValues: tokenValues
+                )
+            }
         }
     }
 
     private func generateFontFamilyTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let fontFamilyRenderParameters = parameters.tokens.fontFamilyRender {
-            try fontFamilyTokensGenerator.generate(
-                renderParameters: fontFamilyRenderParameters,
-                tokenValues: tokenValues
-            )
+        if let fontFamilyRenderParameters = parameters.tokens.fontFamilyRenderParameters {
+            for renderParameters in fontFamilyRenderParameters {
+                try fontFamilyTokensGenerator.generate(
+                    renderParameters: renderParameters,
+                    tokenValues: tokenValues
+                )
+            }
         }
     }
 
     private func generateBaseColorsTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let baseColorRenderParameters = parameters.tokens.baseColorRender {
-            try baseColorTokensGenerator.generate(
-                renderParameters: baseColorRenderParameters,
-                tokenValues: tokenValues
-            )
+        if let baseColorRenderParameters = parameters.tokens.baseColorRenderParameters {
+            for renderParameters in baseColorRenderParameters {
+                try baseColorTokensGenerator.generate(
+                    renderParameters: renderParameters,
+                    tokenValues: tokenValues
+                )
+            }
         }
     }
 
     private func generateColorsTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let colorRenderParameters = parameters.tokens.colorRender {
-            try colorTokensGenerator.generate(
-                renderParameters: colorRenderParameters,
-                tokenValues: tokenValues
-            )
+        if let colorRenderParameters = parameters.tokens.colorRenderParameters {
+            for renderParameters in colorRenderParameters {
+                try colorTokensGenerator.generate(
+                    renderParameters: renderParameters,
+                    tokenValues: tokenValues
+                )
+            }
         }
     }
 

--- a/Sources/FigmaGen/Generators/Tokens/DefaultTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/DefaultTokensGenerator.swift
@@ -55,76 +55,70 @@ final class DefaultTokensGenerator: TokensGenerator {
     }
 
     private func generateSpacingTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let spacingRenderParameters = parameters.tokens.spacingRenderParameters {
-            for renderParameters in spacingRenderParameters {
-                try spacingTokensGenerator.generate(
-                    renderParameters: renderParameters,
-                    tokenValues: tokenValues
-                )
-            }
-        }
+        try generateTokens(
+            spacingTokensGenerator,
+            renderParameters: parameters.tokens.spacingRenderParameters,
+            tokenValues: tokenValues
+        )
     }
 
     private func generateThemeTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let themeRenderParameters = parameters.tokens.themeRenderParameters {
-            for renderParameters in themeRenderParameters {
-                try themeTokensGenerator.generate(
-                    renderParameters: renderParameters,
-                    tokenValues: tokenValues
-                )
-            }
-        }
+        try generateTokens(
+            themeTokensGenerator,
+            renderParameters: parameters.tokens.themeRenderParameters,
+            tokenValues: tokenValues
+        )
     }
 
     private func generateBoxShadowTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let boxShadowRenderParameters = parameters.tokens.boxShadowRenderParameters {
-            for renderParameters in boxShadowRenderParameters {
-                try boxShadowTokensGenerator.generate(
-                    renderParameters: renderParameters,
-                    tokenValues: tokenValues
-                )
-            }
-        }
+        try generateTokens(
+            boxShadowTokensGenerator,
+            renderParameters: parameters.tokens.boxShadowRenderParameters,
+            tokenValues: tokenValues
+        )
     }
 
     private func generateTypographyTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let typographyRenderParameters = parameters.tokens.typographyRenderParameters {
-            for renderParameters in typographyRenderParameters {
-                try typographyTokensGenerator.generate(
-                    renderParameters: renderParameters,
-                    tokenValues: tokenValues
-                )
-            }
-        }
+        try generateTokens(
+            typographyTokensGenerator,
+            renderParameters: parameters.tokens.typographyRenderParameters,
+            tokenValues: tokenValues
+        )
     }
 
     private func generateFontFamilyTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let fontFamilyRenderParameters = parameters.tokens.fontFamilyRenderParameters {
-            for renderParameters in fontFamilyRenderParameters {
-                try fontFamilyTokensGenerator.generate(
-                    renderParameters: renderParameters,
-                    tokenValues: tokenValues
-                )
-            }
-        }
+        try generateTokens(
+            fontFamilyTokensGenerator,
+            renderParameters: parameters.tokens.fontFamilyRenderParameters,
+            tokenValues: tokenValues
+        )
     }
 
     private func generateBaseColorsTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let baseColorRenderParameters = parameters.tokens.baseColorRenderParameters {
-            for renderParameters in baseColorRenderParameters {
-                try baseColorTokensGenerator.generate(
-                    renderParameters: renderParameters,
-                    tokenValues: tokenValues
-                )
-            }
-        }
+        try generateTokens(
+            baseColorTokensGenerator,
+            renderParameters: parameters.tokens.baseColorRenderParameters,
+            tokenValues: tokenValues
+        )
     }
 
     private func generateColorsTokens(parameters: TokensGenerationParameters, tokenValues: TokenValues) throws {
-        if let colorRenderParameters = parameters.tokens.colorRenderParameters {
-            for renderParameters in colorRenderParameters {
-                try colorTokensGenerator.generate(
-                    renderParameters: renderParameters,
+        try generateTokens(
+            colorTokensGenerator,
+            renderParameters: parameters.tokens.colorRenderParameters,
+            tokenValues: tokenValues
+        )
+    }
+
+    private func generateTokens(
+        _ generator: BaseTokenGenerator,
+        renderParameters: [RenderParameters]?,
+        tokenValues: TokenValues
+    ) throws {
+        if let renderParametersList = renderParameters {
+            for params in renderParametersList {
+                try generator.generate(
+                    renderParameters: params,
                     tokenValues: tokenValues
                 )
             }

--- a/Sources/FigmaGen/Generators/Tokens/GenerationParametersResolver/DefaultTokensGenerationParametersResolver.swift
+++ b/Sources/FigmaGen/Generators/Tokens/GenerationParametersResolver/DefaultTokensGenerationParametersResolver.swift
@@ -37,29 +37,6 @@ final class DefaultTokensGenerationParametersResolver: TokensGenerationParameter
     }
 
     private func resolveRenderParameters(
-        template: TokensTemplateConfiguration.Template?,
-        nativeTemplateName: String
-    ) -> RenderParameters? {
-        guard let templateConfiguration = template else {
-            return nil
-        }
-
-        let templateType = resolveTemplateType(
-            template: templateConfiguration,
-            nativeTemplateName: nativeTemplateName
-        )
-
-        let destination = resolveDestination(template: templateConfiguration)
-
-        let template = RenderTemplate(
-            type: templateType,
-            options: templateConfiguration.templateOptions ?? [:]
-        )
-
-        return RenderParameters(template: template, destination: destination)
-    }
-
-    private func resolveRenderParameters(
         templates: [TokensTemplateConfiguration.Template]?,
         nativeTemplateName: String
     ) -> [RenderParameters]? {
@@ -102,33 +79,33 @@ final class DefaultTokensGenerationParametersResolver: TokensGenerationParameter
             accessToken: accessToken
         )
 
-        let colorRender = resolveRenderParameters(
-            template: configuration.templates?.colors,
+        let colorRenderParameters = resolveRenderParameters(
+            templates: configuration.templates?.colors,
             nativeTemplateName: "ColorTokens"
         )
 
-        let baseColorRender = resolveRenderParameters(
-            template: configuration.templates?.baseColors,
+        let baseColorRenderParameters = resolveRenderParameters(
+            templates: configuration.templates?.baseColors,
             nativeTemplateName: "BaseColorTokens"
         )
 
-        let fontFamilyRender = resolveRenderParameters(
-            template: configuration.templates?.fontFamilies,
+        let fontFamilyRenderParameters = resolveRenderParameters(
+            templates: configuration.templates?.fontFamilies,
             nativeTemplateName: "FontFamilyTokens"
         )
 
-        let typographyRender = resolveRenderParameters(
-            template: configuration.templates?.typographies,
+        let typographyRenderParameters = resolveRenderParameters(
+            templates: configuration.templates?.typographies,
             nativeTemplateName: "TypographyTokens"
         )
 
-        let boxShadowRender = resolveRenderParameters(
-            template: configuration.templates?.boxShadows,
+        let boxShadowRenderParameters = resolveRenderParameters(
+            templates: configuration.templates?.boxShadows,
             nativeTemplateName: "BoxShadowTokens"
         )
 
-        let themeRender = resolveRenderParameters(
-            template: configuration.templates?.theme,
+        let themeRenderParameters = resolveRenderParameters(
+            templates: configuration.templates?.theme,
             nativeTemplateName: "Theme"
         )
 
@@ -140,12 +117,12 @@ final class DefaultTokensGenerationParametersResolver: TokensGenerationParameter
         return TokensGenerationParameters(
             file: file,
             tokens: TokensGenerationParameters.TokensParameters(
-                colorRender: colorRender,
-                baseColorRender: baseColorRender,
-                fontFamilyRender: fontFamilyRender,
-                typographyRender: typographyRender,
-                boxShadowRender: boxShadowRender,
-                themeRender: themeRender,
+                colorRenderParameters: colorRenderParameters,
+                baseColorRenderParameters: baseColorRenderParameters,
+                fontFamilyRenderParameters: fontFamilyRenderParameters,
+                typographyRenderParameters: typographyRenderParameters,
+                boxShadowRenderParameters: boxShadowRenderParameters,
+                themeRenderParameters: themeRenderParameters,
                 spacingRenderParameters: spacingRenderParameters
             )
         )

--- a/Sources/FigmaGen/Generators/Tokens/GenerationParametersResolver/DefaultTokensGenerationParametersResolver.swift
+++ b/Sources/FigmaGen/Generators/Tokens/GenerationParametersResolver/DefaultTokensGenerationParametersResolver.swift
@@ -59,6 +59,31 @@ final class DefaultTokensGenerationParametersResolver: TokensGenerationParameter
         return RenderParameters(template: template, destination: destination)
     }
 
+    private func resolveRenderParameters(
+        templates: [TokensTemplateConfiguration.Template]?,
+        nativeTemplateName: String
+    ) -> [RenderParameters]? {
+        guard let templateConfigurations = templates else {
+            return nil
+        }
+
+        return templateConfigurations.map { template -> RenderParameters in
+            let templateType = resolveTemplateType(
+                template: template,
+                nativeTemplateName: nativeTemplateName
+            )
+
+            let destination = resolveDestination(template: template)
+
+            let template = RenderTemplate(
+                type: templateType,
+                options: template.templateOptions ?? [:]
+            )
+
+            return RenderParameters(template: template, destination: destination)
+        }
+    }
+
     // MARK: -
 
     // swiftlint:disable:next function_body_length
@@ -107,8 +132,8 @@ final class DefaultTokensGenerationParametersResolver: TokensGenerationParameter
             nativeTemplateName: "Theme"
         )
 
-        let spacingRender = resolveRenderParameters(
-            template: configuration.templates?.spacing,
+        let spacingRenderParameters = resolveRenderParameters(
+            templates: configuration.templates?.spacing,
             nativeTemplateName: "SpacingTokens"
         )
 
@@ -121,7 +146,7 @@ final class DefaultTokensGenerationParametersResolver: TokensGenerationParameter
                 typographyRender: typographyRender,
                 boxShadowRender: boxShadowRender,
                 themeRender: themeRender,
-                spacingRender: spacingRender
+                spacingRenderParameters: spacingRenderParameters
             )
         )
     }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/BaseColor/BaseColorTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/BaseColor/BaseColorTokensGenerator.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-protocol BaseColorTokensGenerator {
+protocol BaseColorTokensGenerator: BaseTokenGenerator {
 
-    // MARK: - Instance Methods
-
-    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/BaseColor/BaseColorTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/BaseColor/BaseColorTokensGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
 
 protocol BaseColorTokensGenerator: BaseTokenGenerator {
-
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/BaseTokenGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/BaseTokenGenerator.swift
@@ -5,5 +5,4 @@ protocol BaseTokenGenerator {
     // MARK: - Instance Methods
 
     func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
-
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/BaseTokenGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/BaseTokenGenerator.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol BaseTokenGenerator {
+
+    // MARK: - Instance Methods
+
+    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
+
+}

--- a/Sources/FigmaGen/Generators/Tokens/Generators/BoxShadow/BoxShadowTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/BoxShadow/BoxShadowTokensGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
 
-protocol BoxShadowTokensGenerator : BaseTokenGenerator {
-
+protocol BoxShadowTokensGenerator: BaseTokenGenerator {
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/BoxShadow/BoxShadowTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/BoxShadow/BoxShadowTokensGenerator.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-protocol BoxShadowTokensGenerator {
+protocol BoxShadowTokensGenerator : BaseTokenGenerator {
 
-    // MARK: - Instance Methods
-
-    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Color/ColorTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Color/ColorTokensGenerator.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-protocol ColorTokensGenerator {
+protocol ColorTokensGenerator : BaseTokenGenerator {
 
-    // MARK: - Instance Methods
-
-    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Color/ColorTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Color/ColorTokensGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
 
-protocol ColorTokensGenerator : BaseTokenGenerator {
-
+protocol ColorTokensGenerator: BaseTokenGenerator {
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/FontFamily/FontFamilyTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/FontFamily/FontFamilyTokensGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
 
-protocol FontFamilyTokensGenerator : BaseTokenGenerator {
-
+protocol FontFamilyTokensGenerator: BaseTokenGenerator {
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/FontFamily/FontFamilyTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/FontFamily/FontFamilyTokensGenerator.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-protocol FontFamilyTokensGenerator {
+protocol FontFamilyTokensGenerator : BaseTokenGenerator {
 
-    // MARK: - Instance Methods
-
-    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Spacing/SpacingTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Spacing/SpacingTokensGenerator.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-protocol SpacingTokensGenerator {
+protocol SpacingTokensGenerator : BaseTokenGenerator {
 
-    // MARK: - Instance Methods
-
-    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Spacing/SpacingTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Spacing/SpacingTokensGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
 
-protocol SpacingTokensGenerator : BaseTokenGenerator {
-
+protocol SpacingTokensGenerator: BaseTokenGenerator {
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Theme/ThemeTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Theme/ThemeTokensGenerator.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-protocol ThemeTokensGenerator {
+protocol ThemeTokensGenerator : BaseTokenGenerator {
 
-    // MARK: - Instance Methods
-
-    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Theme/ThemeTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Theme/ThemeTokensGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
 
-protocol ThemeTokensGenerator : BaseTokenGenerator {
-
+protocol ThemeTokensGenerator: BaseTokenGenerator {
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Typography/TypographyTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Typography/TypographyTokensGenerator.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-protocol TypographyTokensGenerator {
+protocol TypographyTokensGenerator : BaseTokenGenerator {
 
-    // MARK: - Instance Methods
-
-    func generate(renderParameters: RenderParameters, tokenValues: TokenValues) throws
 }

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Typography/TypographyTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Typography/TypographyTokensGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
 
-protocol TypographyTokensGenerator : BaseTokenGenerator {
-
+protocol TypographyTokensGenerator: BaseTokenGenerator {
 }

--- a/Sources/FigmaGen/Models/Configuration/Tokens/TokensTemplateConfiguration.swift
+++ b/Sources/FigmaGen/Models/Configuration/Tokens/TokensTemplateConfiguration.swift
@@ -34,7 +34,7 @@ struct TokensTemplateConfiguration: Decodable {
     let typographies: Template?
     let boxShadows: Template?
     let theme: Template?
-    let spacing: Template?
+    let spacing: [Template]?
 }
 
 extension TokensTemplateConfiguration.Template {

--- a/Sources/FigmaGen/Models/Configuration/Tokens/TokensTemplateConfiguration.swift
+++ b/Sources/FigmaGen/Models/Configuration/Tokens/TokensTemplateConfiguration.swift
@@ -28,12 +28,12 @@ struct TokensTemplateConfiguration: Decodable {
 
     // MARK: - Instance Properties
 
-    let colors: Template?
-    let baseColors: Template?
-    let fontFamilies: Template?
-    let typographies: Template?
-    let boxShadows: Template?
-    let theme: Template?
+    let colors: [Template]?
+    let baseColors: [Template]?
+    let fontFamilies: [Template]?
+    let typographies: [Template]?
+    let boxShadows: [Template]?
+    let theme: [Template]?
     let spacing: [Template]?
 }
 

--- a/Sources/FigmaGen/Models/Configuration/Tokens/TokensTemplateConfiguration.swift
+++ b/Sources/FigmaGen/Models/Configuration/Tokens/TokensTemplateConfiguration.swift
@@ -1,11 +1,11 @@
 import Foundation
 import FigmaGenTools
 
-struct TokensTemplateConfiguration: Decodable {
+struct TokensTemplateConfiguration {
 
     // MARK: - Nested Types
 
-    struct Template: Decodable {
+    struct Template {
 
         // MARK: - Instance Properties
 
@@ -37,7 +37,61 @@ struct TokensTemplateConfiguration: Decodable {
     let spacing: [Template]?
 }
 
-extension TokensTemplateConfiguration.Template {
+// MARK: - Decodable
+
+extension TokensTemplateConfiguration: Decodable {
+
+    // MARK: - Nested Types
+
+    private enum CodingKeys: String, CodingKey {
+        case colors
+        case baseColors
+        case fontFamilies
+        case typographies
+        case boxShadows
+        case theme
+        case spacing
+    }
+
+    private struct TemplateWrapper: Decodable {
+
+        // MARK: - Instance Properties
+
+        let templates: [Template]?
+
+        // MARK: - Initializers
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+
+            if container.decodeNil() {
+                self.templates = nil
+            } else if let singleValue = try? container.decode(Template.self) {
+                self.templates = [singleValue]
+            } else {
+                self.templates = try container.decode([Template].self)
+            }
+        }
+    }
+
+    // MARK: - Initializers
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.colors = try container.decode(TemplateWrapper.self, forKey: .colors).templates
+        self.baseColors = try container.decode(TemplateWrapper.self, forKey: .baseColors).templates
+        self.fontFamilies = try container.decode(TemplateWrapper.self, forKey: .fontFamilies).templates
+        self.typographies = try container.decode(TemplateWrapper.self, forKey: .typographies).templates
+        self.boxShadows = try container.decode(TemplateWrapper.self, forKey: .boxShadows).templates
+        self.theme = try container.decode(TemplateWrapper.self, forKey: .theme).templates
+        self.spacing = try container.decode(TemplateWrapper.self, forKey: .spacing).templates
+    }
+}
+
+// MARK: -
+
+extension TokensTemplateConfiguration.Template: Decodable {
 
     // MARK: - Nested Types
 

--- a/Sources/FigmaGen/Models/Parameters/TokensGenerationParameters.swift
+++ b/Sources/FigmaGen/Models/Parameters/TokensGenerationParameters.swift
@@ -14,7 +14,7 @@ struct TokensGenerationParameters {
         let typographyRender: RenderParameters?
         let boxShadowRender: RenderParameters?
         let themeRender: RenderParameters?
-        let spacingRender: RenderParameters?
+        let spacingRenderParameters: [RenderParameters]?
     }
 
     // MARK: - Instance Properties

--- a/Sources/FigmaGen/Models/Parameters/TokensGenerationParameters.swift
+++ b/Sources/FigmaGen/Models/Parameters/TokensGenerationParameters.swift
@@ -8,12 +8,12 @@ struct TokensGenerationParameters {
 
         // MARK: - Instance Properties
 
-        let colorRender: RenderParameters?
-        let baseColorRender: RenderParameters?
-        let fontFamilyRender: RenderParameters?
-        let typographyRender: RenderParameters?
-        let boxShadowRender: RenderParameters?
-        let themeRender: RenderParameters?
+        let colorRenderParameters: [RenderParameters]?
+        let baseColorRenderParameters: [RenderParameters]?
+        let fontFamilyRenderParameters: [RenderParameters]?
+        let typographyRenderParameters: [RenderParameters]?
+        let boxShadowRenderParameters: [RenderParameters]?
+        let themeRenderParameters: [RenderParameters]?
         let spacingRenderParameters: [RenderParameters]?
     }
 


### PR DESCRIPTION
Добавляет поддержку генерации нескольких файлов из одного типа токенов. 
Для CLI-версии поддержку добавлять не стал, есть сомнения в том, что это вообще будет удобно.

Сразу подсвечу, что для применения новой версии генератора с файлом-конфигурации, придётся немного модифицировать файл конфигурации. Вместо

```yaml
spacings:
    template: path/to/template.stencil
    destination: path/to/destination.stencil
```

придётся писать вот так (добавился `-` для изменения типа элемента):

```yaml
spacings:
    - template: path/to/template.stencil
      destination: path/to/destination.stencil
```