### PR TITLE
MOB-36756: Зафиксировать порядок свойств в Contents.json файлах иконок

### DIFF
--- a/Sources/FigmaGenTools/Assets/AssetNode.swift
+++ b/Sources/FigmaGenTools/Assets/AssetNode.swift
@@ -46,7 +46,7 @@ extension AssetNode {
 
         try folderPath.mkpath()
 
-        let contentsEncoder = JSONEncoder(outputFormatting: .prettyPrinted)
+        let contentsEncoder = JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys])
         let contentsData = try contentsEncoder.encode(contents)
         let contentsPath = folderPath.appending(.contentsPath)
 

--- a/Sources/FigmaGenTools/Assets/Folder/AssetFolder.swift
+++ b/Sources/FigmaGenTools/Assets/Folder/AssetFolder.swift
@@ -96,7 +96,7 @@ public struct AssetFolder {
         try saveNodes(imageSets, in: folderPath)
         try saveFolders(in: folderPath)
 
-        let contentsEncoder = JSONEncoder(outputFormatting: .prettyPrinted)
+        let contentsEncoder = JSONEncoder(outputFormatting: [.prettyPrinted, .sortedKeys])
         let contentsData = try contentsEncoder.encode(contents)
         let contentsPath = folderPath.appending(.contentsPath)
 


### PR DESCRIPTION
Решает проблему большого количества бесполезных изменений вроде вот таких - когда после экспорта просто изменился порядок свойств в Contents-файле. 
![image (12)](https://github.com/hhru/FigmaGen/assets/13614672/0b46cf6f-0a6f-4588-ab17-7196dc2371dd)
