### PR TITLE
MOB-38596: Исправить загрузку картинок

### DIFF
--- a/Sources/FigmaGen/Providers/Images/Render/DefaultImageRenderProvider.swift
+++ b/Sources/FigmaGen/Providers/Images/Render/DefaultImageRenderProvider.swift
@@ -101,12 +101,18 @@ final class DefaultImageRenderProvider: ImageRenderProvider {
             return .value([])
         }
 
-        let promises = scales.map { scale in
-            renderImages(of: file, nodes: nodes, format: format, scale: scale, useAbsoluteBounds: useAbsoluteBounds)
-                .map { imageURLs in
-                    (scale: scale, imageURLs: imageURLs)
-                }
-        }
+        let promises = scales
+            .map { scale in
+                nodes
+                    .chunked(size: 100)
+                    .map { nodesPars in
+                        renderImages(of: file, nodes: nodesPars, format: format, scale: scale, useAbsoluteBounds: useAbsoluteBounds)
+                            .map { imageURLs in
+                                (scale: scale, imageURLs: imageURLs)
+                            }
+                    }
+            }
+            .flatMap { $0 }
 
         return firstly {
             when(fulfilled: promises)

--- a/Sources/FigmaGenTools/Extensions/Array+Extensions.swift
+++ b/Sources/FigmaGenTools/Extensions/Array+Extensions.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Array {
+
+    public func chunked(size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}


### PR DESCRIPTION
[MOB-38596](https://jira.hh.ru/browse/MOB-38596) Исправить загрузку картинок

Опытным путем выяснила, что падает при отправке 324 `node` за раз )) но число не красивое ( xD ), пока поставила различение на чанки по 100 `node`