### PR TITLE
[MOB-60077] Добавляет проброс rawValues в токены letterSpacing из Figma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ env:
 jobs:
   macOS:
     name: macOS
-    runs-on: macOS-13
+    runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
       SWIFTLINT_VERSION: 0.52.2
       DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+      FIGMAGEN_ACCESS_TOKEN: ${{ secrets.FIGMAGEN_ACCESS_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Ruby
         uses: ruby/setup-ruby@v1
       - name: Bundler
@@ -49,7 +50,7 @@ jobs:
     container:
       image: swift:5.9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           apt-get update
@@ -72,7 +73,7 @@ jobs:
     name: CocoaPods
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Ruby
         uses: ruby/setup-ruby@v1
       - name: Bundler

--- a/Demo/.figmagen.yml
+++ b/Demo/.figmagen.yml
@@ -1,5 +1,6 @@
 base:
-  accessToken: 25961-4ac9fbc9-3bd8-4c43-bbe2-95e477f8a067
+  accessToken:
+    env: FIGMAGEN_ACCESS_TOKEN
 
 colorStyles:
   file: https://www.figma.com/file/61xw2FQn61Xr7VVFYwiHHy/Fugen-Demo?node-id=91%3A3

--- a/Sources/FigmaGen/Generators/Tokens/Contexts/TypographyToken.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Contexts/TypographyToken.swift
@@ -6,11 +6,19 @@ struct TypographyToken {
 
     typealias FontSizeToken = ContextToken
     typealias FontScaleToken = ContextToken
-    typealias LetterSpacingToken = ContextToken
     typealias LineHeightToken = ContextToken
     typealias TextDecorationToken = ContextToken
     typealias ParagraphSpacingToken = ContextToken
     typealias ParagraphIndentToken = ContextToken
+
+    struct LetterSpacingToken {
+
+        // MARK: - Instance Properties
+
+        let path: [String]
+        let value: String
+        let rawValue: String
+    }
 
     // MARK: - Instance Properties
 

--- a/Sources/FigmaGen/Generators/Tokens/Generators/Typography/DefaultTypographyTokensGenerator.swift
+++ b/Sources/FigmaGen/Generators/Tokens/Generators/Typography/DefaultTypographyTokensGenerator.swift
@@ -85,7 +85,8 @@ final class DefaultTypographyTokensGenerator: TypographyTokensGenerator {
 
         return TypographyToken.LetterSpacingToken(
             path: letterSpacingValue.components(separatedBy: "."),
-            value: String(round(fontLetterSpacing * 100) / 100.0)
+            value: String(round(fontLetterSpacing * 100) / 100.0),
+            rawValue: String(letterSpacing)
         )
     }
 


### PR DESCRIPTION
Для чего потребовалось: в Android более корректно задавать `letterSpacing` не в абсолютных значениях, а в относительных. Figma Token Studio как раз отдаёт нам значения `letterSpacing` в процентах (например, `0.50%`), что должно превращаться в `0.005.em`. Однако до изменений в этом PR, FigmaGen специально вычислял абсолютное значение. 

Да, можно было бы из `LetterSpacingToken.value` вычислить проценты обратно, но зачем, если можно их просто пробросить для дальнейшего использования?